### PR TITLE
Make output formatting nicer

### DIFF
--- a/tasks/project.js
+++ b/tasks/project.js
@@ -10,6 +10,7 @@ const webpackServer = require('@hedviginsurance/web-survival-kit/webpack/webpack
 const { print, printError } = require('../utils/io')
 const config = require('./config')
 
+const formatStats = (process, stats) => `[${process}] ----> ${stats.toString().split('\n').join(`\n[${process}] ----> `)}`
 const watch = (config) => {
   print('Starting development server, watching for changes 👀')
   const port = config.port || 8081
@@ -34,7 +35,7 @@ const watch = (config) => {
   }))
 
   const wds = new WDS(clientCompiler, clientConfig.devServer)
-  wds.listen(clientConfig.devServer.port, () => {
+  wds.listen(clientConfig.devServer.port, undefined, () => {
     print(`WDS listening on ${clientConfig.devServer.port} 👂`)
   })
 
@@ -44,8 +45,8 @@ const watch = (config) => {
       return
     }
 
+    print(formatStats('server', stats))
     print('Server change built successfully ✅')
-    print(stats.toString())
   })
   nodemon({ script: path.resolve(config.serverPath, 'index.js') })
 }
@@ -76,8 +77,8 @@ const build = (config) => {
       return
     }
 
+    print(formatStats('client', stats))
     print('Client built successfully ✅')
-    print(stats.toString())
   })
   serverCompiler.run((err, stats) => {
     if (err) {
@@ -86,8 +87,8 @@ const build = (config) => {
       return
     }
 
+    print(formatStats('server', stats))
     print('Server built successfully ✅')
-    print(stats.toString())
   })
 }
 


### PR DESCRIPTION
Will give us something like:
```
Building production bundle 🏗
[server] ----> Hash: a4a4c79ed27db19c13d5
[server] ----> Version: webpack 4.19.1
[server] ----> Time: 966ms
[server] ----> Built at: 2018-09-21 14:25:57
[server] ---->        Asset      Size  Chunks             Chunk Names
[server] ---->     index.js  3.39 KiB       0  [emitted]  main
[server] ----> index.js.map  8.44 KiB       0  [emitted]  main
[server] ----> Entrypoint main = index.js index.js.map
[server] ----> [./src/serverEntry.tsx] ./src/serverEntry.tsx + 1 modules 3.04 KiB {0} [built]
[server] ---->     | ./src/serverEntry.tsx 2.76 KiB [built]
[server] ---->     | ./src/App.tsx 251 bytes [built]
[server] ----> [@babel/polyfill] external "@babel/polyfill" 42 bytes {0} [built]
[server] ----> [@hedviginsurance/web-survival-kit] external "@hedviginsurance/web-survival-kit" 42 bytes {0} [built]
[server] ----> [emotion-server] external "emotion-server" 42 bytes {0} [built]
[server] ----> [path] external "path" 42 bytes {0} [built]
[server] ----> [react] external "react" 42 bytes {0} [built]
[server] ----> [react-dom/server] external "react-dom/server" 42 bytes {0} [built]
[server] ----> [react-emotion] external "react-emotion" 42 bytes {0} [built]
[server] ----> [source-map-support/register] external "source-map-support/register" 42 bytes {0} [built]
[server] ----> [0] multi @babel/polyfill ./src/serverEntry.tsx 40 bytes {0} [built]
Server built successfully ✅
```